### PR TITLE
Strip endpoint hostname trailing slash

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -385,7 +385,7 @@ class LocalstackPlugin {
     const endpoints = plugin.gatheredData.info.endpoints || [];
     const edgePort = this.getEdgePort();
     endpoints.forEach((entry, idx) => {
-      // Strip trailing slash
+      // Strip trailing slash at the end of the hostname
       entry = entry.endsWith("/") ? entry.slice(0, -1) : entry;
 
       // endpoint format for old Serverless versions

--- a/src/index.js
+++ b/src/index.js
@@ -385,6 +385,9 @@ class LocalstackPlugin {
     const endpoints = plugin.gatheredData.info.endpoints || [];
     const edgePort = this.getEdgePort();
     endpoints.forEach((entry, idx) => {
+      // Strip trailing slash
+      entry = entry.endsWith("/") ? entry.slice(0, -1) : entry;
+
       // endpoint format for old Serverless versions
       const regex = /[^\s:]*:\/\/([^.]+)\.execute-api[^/]+\/([^/]+)(\/.*)?/g;
       const replace = `http://localhost:${edgePort}/restapis/$1/$2/_user_request_$3`;


### PR DESCRIPTION
Not stripping the trailing slash leads to malformed URLs in the output, like so: https://7d7c2bf6.execute-api.localhost.localstack.cloud:4566//local/task

